### PR TITLE
Fix bug where arb includes a mix of arbs and strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,6 @@ rlwrap bin/repl
 To run the server do:
 
 ```
-lein ring server
+lein ring server <desired-port-#>
 ```
 

--- a/src/datemo/arb.clj
+++ b/src/datemo/arb.clj
@@ -36,15 +36,19 @@
 
 (defn arb->tx [arb]
   (let [[arb-tag metadata & value] arb]
-    (if (or (string? (first value)) (nil? (first value)))
+    (if (and
+          (= 1 (count value))
+          (or (string? (first value)) (nil? (first value))))
       {:arb/metadata [{:metadata/html-tag (metadata :original-tag)}]
        :arb/value [{:content/text (first value)}]}
       (loop [values []
              items value]
+        (def new-val (if (string? (first items))
+                       (first items) (arb->tx (first items))))
         (if (= 1 (count items))
           {:arb/metadata [{:metadata/html-tag (metadata :original-tag)}]
-           :arb/value (conj values (arb->tx (first items)))}
-          (recur (conj values (arb->tx (first items))) (next items)))))))
+           :arb/value (conj values new-val)}
+          (recur (conj values new-val) (next items)))))))
 
 (defn html->tx [html & metadata]
   (let [tx (-> html (html->arb) (arb->tx))]

--- a/src/datemo/routes.clj
+++ b/src/datemo/routes.clj
@@ -219,30 +219,30 @@
                             :html doc-html}}}))))
 
 (defn post-doc [doc-string doctype title tags]
- (let [id (d/squuid)
-       tx (-> (html->tx
-                (md-to-html-string doc-string)
-                {:metadata/title (or title "Untitled")}
-                {:metadata/doctype (keyword "doctype" doctype)}
-                (gen-tags-meta tags))
-              (into {:arb/id id}) (edn->clj))
-       [tx-result tx-error] (db/transact-or-error [tx])]
-   (if (nil? tx-error)
-     (let [db-after (:db-after tx-result)
-           new-doc (d/pull db-after '[*] [:arb/id id])
-           html (-> new-doc (tx->arb) (arb->hiccup) (html))]
-       {:status 201
-        :headers {"Content-Type" "application/hal+json; charset=utf-8"}
-        :body {:_links {:self {:href (apply str "/documents/" (str id))}}
-               :_embedded {:id id
-                           :title (get-title (:arb/metadata new-doc))
-                           :doctype (get-doctype (:arb/metadata new-doc))
-                           :created-at (get-created-at id db-after)
-                           :updated-at (get-updated-at id db-after)
-                           :tags (get-tags (:arb/metadata new-doc))
-                           :html html}}})
-     {:status 500
-      :body {:error (apply str "Error posting: " tx-error)}})))
+  (let [id (d/squuid)
+        tx (-> (html->tx
+                 (md-to-html-string doc-string)
+                 {:metadata/title (or title "Untitled")}
+                 {:metadata/doctype (keyword "doctype" doctype)}
+                 (gen-tags-meta tags))
+               (into {:arb/id id}) (edn->clj))
+        [tx-result tx-error] (db/transact-or-error [tx])]
+    (if (nil? tx-error)
+      (let [db-after (:db-after tx-result)
+            new-doc (d/pull db-after '[*] [:arb/id id])
+            html (-> new-doc (tx->arb) (arb->hiccup) (html))]
+        {:status 201
+         :headers {"Content-Type" "application/hal+json; charset=utf-8"}
+         :body {:_links {:self {:href (apply str "/documents/" (str id))}}
+                :_embedded {:id id
+                            :title (get-title (:arb/metadata new-doc))
+                            :doctype (get-doctype (:arb/metadata new-doc))
+                            :created-at (get-created-at id db-after)
+                            :updated-at (get-updated-at id db-after)
+                            :tags (get-tags (:arb/metadata new-doc))
+                            :html html}}})
+      {:status 500
+       :body {:error (apply str "Error posting: " tx-error)}})))
 
 (defroutes app-routes
   (GET "/" [] {:body {:_links {:documents {:href "/docs"}}}})

--- a/test/datemo/arb_test.clj
+++ b/test/datemo/arb_test.clj
@@ -65,11 +65,10 @@
     (testing "arb with emphasis markup"
       (is (=
            {:arb/metadata [{:metadata/html-tag :div}],
-            :arb/value
-            ["This is "
-             {:arb/metadata [{:metadata/html-tag :em}],
-              :arb/value [{:content/text "italic"}]}
-             "text"]}
+            :arb/value [{:content/text "This is "}
+                        {:arb/metadata [{:metadata/html-tag :em}],
+                         :arb/value [{:content/text "italic"}]}
+                        {:content/text "text"}]}
            (arb->tx [:arb
                      {:original-tag :div}
                      "This is " [:arb {:original-tag :em} "italic"] "text"]))))
@@ -100,7 +99,7 @@
              {:arb/metadata [{:metadata/html-tag :div}]
               :arb/value [{:arb/metadata [{:metadata/html-tag :p}]
                            :arb/value [{:content/text "paragraph"}]}]}))))
-    (testing "with single-level nested arb with siblings"
+    (testing "with single-level nested arb with multiple arb siblings"
       (is (=
            [:arb
             {:original-tag :div}
@@ -111,7 +110,20 @@
               :arb/value [{:arb/metadata [{:metadata/html-tag :h1}]
                            :arb/value [{:content/text "title"}]}
                           {:arb/metadata [{:metadata/html-tag :p}]
-                           :arb/value [{:content/text "paragraph"}]}]})))))
+                           :arb/value [{:content/text "paragraph"}]}]}))))
+    (testing "with single-level nested arb with arb and :content/text siblings"
+      (is (=
+           [:arb
+            {:original-tag :div}
+            "Text with "
+            [:arb {:original-tag :em} "emphasis"]
+            " in between."]
+           (tx->arb
+             {:arb/metadata [{:metadata/html-tag :div}]
+              :arb/value [{:content/text "Text with "}
+                          {:arb/metadata [{:metadata/html-tag :em}]
+                           :arb/value [{:content/text "emphasis"}]}
+                          {:content/text " in between."}]})))))
 
   (testing "arb->hiccup"
     (testing "single node"

--- a/test/datemo/arb_test.clj
+++ b/test/datemo/arb_test.clj
@@ -62,6 +62,17 @@
            {:arb/metadata [{:metadata/html-tag :div}]
             :arb/value [{:content/text "Text"}]}
            (arb->tx [:arb {:original-tag :div} "Text"]))))
+    (testing "arb with emphasis markup"
+      (is (=
+           {:arb/metadata [{:metadata/html-tag :div}],
+            :arb/value
+            ["This is "
+             {:arb/metadata [{:metadata/html-tag :em}],
+              :arb/value [{:content/text "italic"}]}
+             "text"]}
+           (arb->tx [:arb
+                     {:original-tag :div}
+                     "This is " [:arb {:original-tag :em} "italic"] "text"]))))
     (testing "arb with nested arb"
       (is (=
            {:arb/metadata [{:metadata/html-tag :div}]


### PR DESCRIPTION
Connects to #23 and solves #23. The problem was that the arb->tx function could not handle the case where an arb had multiple values consisting of a mix of plain strings or other arbs.