### PR TITLE
Switch to m3.medium aws instance

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - "8080:8080"
     environment:
       - DATEMO_DB_URI=datomic:ddb://us-east-1/datemo/datemo
-      - VIRTUAL_HOST=138.197.7.39
+      - VIRTUAL_HOST=54.145.19.85
     secrets:
       - aws_access_key
       - aws_secret_access_key

--- a/resources/cf.json
+++ b/resources/cf.json
@@ -92,7 +92,7 @@
  {"InstanceType":
   {"Description":"Type of EC2 instance to launch",
    "Type":"String",
-   "Default":"c3.large"},
+   "Default":"m3.medium"},
   "InstanceProfile":
   {"Description":"Preexisting IAM role \/ instance profile",
    "Type":"String",

--- a/resources/datemo-cf.properties
+++ b/resources/datemo-cf.properties
@@ -21,7 +21,7 @@ aws-autoscaling-group-size=1
 
 # required, default = 70% of AWS instance RAM
 # Passed to java launcher via -Xmx
-java-xmx=2625m
+java-xmx=
 
 #################################################################
 # Java VM options
@@ -67,4 +67,3 @@ datomic-version=0.9.5544
 datomic-deploy-s3-bucket=deploy-a0dbc565-faf2-4760-9b7e-29a8e45f428e
 
 
-java-opts=


### PR DESCRIPTION
Trying to reduce costs. There might be a way to get to t2.small, see here: https://stackoverflow.com/questions/45501981/is-there-any-way-to-use-t2-small-ec2-instance-when-deploying-datomic-transactor

