### PR TITLE
Changes attribute name for tag metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8
 ADD ./docker-entrypoint.sh /
-ADD ./target/datemo-0.1.1-standalone.jar /
+ADD ./target/datemo-0.1.2-standalone.jar /
 RUN /bin/bash -c 'chmod u+x /docker-entrypoint.sh'
 ENV PORT=8080
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -57,7 +57,19 @@ To stop it:
 docker stack rm datemo
 ```
 
-**Note:** The `VIRTUAL_HOST` settingin `docker-compose.yml` needs to point to the IP of the
+To see what is running in the stack do:
+
+```
+docker ps
+```
+
+To inspect the logs for one of the processes do:
+
+```
+docker logs <process-name, e.g. "datemo_web.1.myrooeb6ifz71p00bebftgof6">
+```
+
+**Note:** The `VIRTUAL_HOST` setting in `docker-compose.yml` needs to point to the IP of the
 AWS instance where the transactor is running, i.e. the instance that is started when deploying
 the cloud formation in step #2.
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,22 @@ To run the server do:
 lein ring server <desired-port-#>
 ```
 
+Note: You can also run in dev and connect to a transactor on AWS by replacing the database URI
+for dev in the project.clj. This is also useful for updating the schema on an AWS deployed DB:
+
+1) Change the database URI in project.clj
+2) Run the repl with `lein repl`
+3) Do the following in the repl:
+```
+(use 'datemo.db)
+(require '[datomic.api :as d])
+(d/delete-database "<database-uri>")
+(d/create-database "<database-uri>")
+(init-db)
+(-> (load-schema "schemas/arb.edn")
+    (install-schema (get-conn)))
+```
+
 ## To run Datemo to test Production
 
 Assuming the transactor is already running on AWS:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ To run the server do:
 lein ring server <desired-port-#>
 ```
 
+## To run Datemo to test Production
+
+Assuming the transactor is already running on AWS:
+
+1) Build the jar files with:
+```
+lein ring uberjar
+```
+
+2) Run the following command, adding the AWS keys:
+```
+java -Ddatabase.uri="datomic:ddb://us-east-1/datemo/datemo?aws_access_key_id=<fill-in-key>&aws_secret_key=<fill-in-key>" -jar target/datemo-<version#>-standalone.jar
+```
+
 ## Notes on Deployment
 
 Currently, I'm running this instance using Docker and AWS. So the deployment has two steps:
@@ -111,16 +125,17 @@ To deploy the cloud formation, you can do the following:
 ## Rebuilding Docker Image for new version
 
 1. Make sure you've updated the version in `project.clj`.
-2. Update the .jar file specified in the `Dockerfile`.
-3. Build the new docker image:
+2. Build the new jar files by doing: `lein ring uberjar`.
+3. Update the .jar file specified in the `Dockerfile`.
+4. Build the new docker image:
     ```
     docker build --rm -t ezmiller/datemo:latest -t ezmiller/datemo:<version> .
     ```
-4. Push both latest and the new version to the Docker Hub:
+5. Push both latest and the new version to the Docker Hub:
     ```
     docker push ezmiller/datemo:latest
     docker push ezmiller/datemo:<version>
     ```
-5. Now you can do `docker pull` of latest on server and redeploy stack.
+6. Now you can do `docker pull` of latest on server and redeploy stack.
 
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject datemo "0.1.1"
+(defproject datemo "0.1.2"
   :description "Document server backed by datomic"
   :url "https://github.com/ezmiller/datemo"
   :license {:name "Eclipse Public License"

--- a/resources/schemas/arb.edn
+++ b/resources/schemas/arb.edn
@@ -3,16 +3,18 @@
   :db/cardinality      :db.cardinality/one
   :db/index            true}
 
- ;; metadata attributes
+ {:db/ident           :tag/name
+  :db/valueType       :db.type/keyword
+  :db/cardinality     :db.cardinality/one
+  :db/index           true}
+
  {:db/ident            :metadata/empty}
+
+ ;; metadata attributes
  {:db/ident            :metadata/tags
   :db/valueType        :db.type/ref
   :db/cardinality      :db.cardinality/many
   :db/isComponent      true}
- {:db/ident            :metadata/tag
-  :db/valueType        :db.type/keyword
-  :db/cardinality      :db.cardinality/one
-  :db/index            true}
  {:db/ident            :metadata/html-tag
   :db/valueType        :db.type/keyword
   :db/cardinality      :db.cardinality/one}

--- a/src/datemo/routes.clj
+++ b/src/datemo/routes.clj
@@ -27,7 +27,7 @@
   (java.util.UUID/fromString uuid-str))
 
 (defn is-empty-metadata [entity]
-  (= :metadata/empty (:db/ident (pull-entity (:db/id entity)))))
+  (= :empty (:db/ident (pull-entity (:db/id entity)))))
 
 (defn get-title [metadata]
   (get-in-metadata :metadata/title metadata))
@@ -43,12 +43,12 @@
   (def tags (get-in-metadata :metadata/tags metadata))
   (if (or (nil? tags) (is-empty-metadata (first tags)))
     []
-    (mapv #(name (:metadata/tag %)) tags)))
+    (mapv #(name (:tag/name %)) tags)))
 
 (defn gen-tags-meta [tags]
   (if (empty? tags)
-    {:metadata/tags [:metadata/empty]}
-    {:metadata/tags (mapv #(array-map :metadata/tag (keyword (s/trim %))) tags)}))
+    {:metadata/tags [:empty]}
+    {:metadata/tags (mapv #(array-map :tag/name (keyword (s/trim %))) tags)}))
 
 (defn get-updated-at
   ([arb-id] (get-updated-at arb-id (db-now)))
@@ -132,7 +132,7 @@
   (filterv
     (fn [r]
       (let [metadata (-> (first r) (:arb/metadata) (first))
-            tagset (mapv #(:metadata/tag %) (:metadata/tags metadata))
+            tagset (mapv #(:tag/name %) (:metadata/tags metadata))
             tags-to-find (mapv #(keyword %) (if (vector? tags) tags [tags]))
             matched (filterv #(>= (.indexOf tagset %) 0) tags-to-find)]
         (> (count matched) 0)))

--- a/test/datemo/routes_test.clj
+++ b/test/datemo/routes_test.clj
@@ -35,7 +35,7 @@
     :arb/value {:content/text value}
     :arb/metadata {:metadata/html-tag tag
                    :metadata/title title
-                   :metadata/tags (mapv #(array-map :metadata/tag (keyword %)) tags)
+                   :metadata/tags (mapv #(array-map :tag/name (keyword %)) tags)
                    :metadata/doctype (keyword "doctype" doctype)}}])
 
 (deftest test-get-root
@@ -128,7 +128,7 @@
                    :arb/value {:content/text "test"}
                    :arb/metadata {:metadata/html-tag :p
                                   :metadata/doctype :doctype/note
-                                  :metadata/tags [{:metadata/tag :tag1}]
+                                  :metadata/tags [{:tag/name :tag1}]
                                   :metadata/title "A title"}}])
     (let [tx (d/transact (get-conn) tx-spec)
           [_ _ tx-inst] (first (:tx-data @tx))


### PR DESCRIPTION
I basically followed the advice given by "@favila" on the datomic channel in clojurians slack. 

He said:

> {:metadata/tags [{:tag/name "the-name" :tag/whatever "foo"} ...] is the design I would expect

This makes sense to me for the most part. `:tag` is the name space, and `:tag/name` indicates just that: a name for a tag. It doesn't need to be linked to a metadata name space as it was before. If I'd stuck with that association I think the name that would have been most vernacular would be `:metadata.tag/name`.

I also renamed the `:metadata/empty` attribute to `:empty`. I'm increasingly unsure about this attribute anyway. I'm using it as a flag to indicate that there are no tags, but it seems wrong. I can't remember anymore why I felt I needed it in the first place. Perhaps the right solution is just not to have a `:metadata/tags` attribute on the arb when there are not tags at all.