### PR TITLE
Fix empty tag placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ bin/run -m datomic.peer-server -p 8998 -a datemo,datemo -d datemo,datomic:mem://
 
 In order to get the dev db running, you need to run the following commands from the root of the datomic download package:
 
-1) Run transactor:
+1) Run transactor (from datomic directory):
 
 ```
-bin/transactor ~/datemo/resources/dev-transactor.properties
+bin/transactor /path/to/datemo/resources/dev-transactor.properties
 ```
 
 3) (optional) If you want the console:

--- a/resources/schemas/arb.edn
+++ b/resources/schemas/arb.edn
@@ -7,8 +7,7 @@
   :db/valueType       :db.type/keyword
   :db/cardinality     :db.cardinality/one
   :db/index           true}
-
- {:db/ident            :metadata/empty}
+ {:db/ident           :tag/none}
 
  ;; metadata attributes
  {:db/ident            :metadata/tags

--- a/src/datemo/routes.clj
+++ b/src/datemo/routes.clj
@@ -27,7 +27,7 @@
   (java.util.UUID/fromString uuid-str))
 
 (defn is-empty-metadata [entity]
-  (= :empty (:db/ident (pull-entity (:db/id entity)))))
+  (= :tag/none (:db/ident (pull-entity (:db/id entity)))))
 
 (defn get-title [metadata]
   (get-in-metadata :metadata/title metadata))
@@ -47,7 +47,7 @@
 
 (defn gen-tags-meta [tags]
   (if (empty? tags)
-    {:metadata/tags [:empty]}
+    {:metadata/tags [:tag/none]}
     {:metadata/tags (mapv #(array-map :tag/name (keyword (s/trim %))) tags)}))
 
 (defn get-updated-at


### PR DESCRIPTION
The empty tag placeholder in the schema had been named something else: `:empty`,
I think. I am changing it to `:tag/none` here and updating logic in routes.