### PR TITLE
Fix tag filtering on `/latest`

### DIFF
--- a/test/datemo/routes_test.clj
+++ b/test/datemo/routes_test.clj
@@ -106,9 +106,9 @@
   (testing "GET /latest tag filter parameter"
     (let [doc-specs
             [
-             (first (doc-tx-spec (d/squuid) "A title" "essay" :p "test" ["tag1"]))
-             (first (doc-tx-spec (d/squuid) "A title" "essay" :p "test" ["tag2"]))
-             (first (doc-tx-spec (d/squuid) "A title" "essay" :p "test" ["tag1" "tag2"]))
+             (first (doc-tx-spec (d/squuid) "A title" "essay" :p "test" [:tag1]))
+             (first (doc-tx-spec (d/squuid) "A title" "essay" :p "test" [:tag2]))
+             (first (doc-tx-spec (d/squuid) "A title" "essay" :p "test" [:tag1 :tag2]))
              ]
           tx (d/transact (get-conn) doc-specs)
           response1 (handler (request :get "/latest?tags=tag1"))


### PR DESCRIPTION
This fixes the tag filtering mechanism on the /latest route. There was a problem with the parsing of tags from the retrieved document.